### PR TITLE
Ferdigstill tidligere forhåndsvarsel

### DIFF
--- a/src/components/history/HistoricEventsSummary.tsx
+++ b/src/components/history/HistoricEventsSummary.tsx
@@ -1,60 +1,61 @@
-import {AktivitetskravBox} from "@/components/box/AktivitetskravBox";
-import {Heading, LinkPanel} from "@navikt/ds-react";
+import { AktivitetskravBox } from "@/components/box/AktivitetskravBox";
+import { Heading, LinkPanel } from "@navikt/ds-react";
 import NextLink from "next/link";
 import React from "react";
-import {getShortDateFormat} from "@/utils/dateUtils";
-import {AktivitetskravViewItem} from "@/components/view/viewUtils";
-import {ferdigstillVarsel} from "@/data/ferdigstillVarsel";
+import { getShortDateFormat } from "@/utils/dateUtils";
+import { AktivitetskravViewItem } from "@/components/view/viewUtils";
+import { ferdigstillVarsel } from "@/data/ferdigstillVarsel";
 
 const getHeaderText = (viewItem: AktivitetskravViewItem) => {
-    switch (viewItem.type) {
-        case "UNDER_BEHANDLING":
-            return "NAV vurderer aktivitetsplikten din";
-        case "IKKE_OPPFYLT":
-            return "Svarfristen har gått ut";
-        case "FORHANDSVARSEL":
-            return "Forhåndsvarsel om stans av sykepenger";
-        case "MOTTATT_VURDERING":
-            return "Du har mottatt en vurdering av din aktivitetsplikt";
-    }
+  switch (viewItem.type) {
+    case "UNDER_BEHANDLING":
+      return "NAV vurderer aktivitetsplikten din";
+    case "IKKE_OPPFYLT":
+      return "Svarfristen har gått ut";
+    case "FORHANDSVARSEL":
+      return "Forhåndsvarsel om stans av sykepenger";
+    case "MOTTATT_VURDERING":
+      return "Du har mottatt en vurdering av din aktivitetsplikt";
+  }
 };
 
 interface Props {
-    historicVurderinger: AktivitetskravViewItem[] | null;
+  historicVurderinger: AktivitetskravViewItem[] | null;
 }
 
-export const HistoricEventsSummary = ({historicVurderinger}: Props) => {
-    if (historicVurderinger && historicVurderinger.length > 0) {
-
-        const hasHistoricForhaandsvarsel = !!historicVurderinger.find((item) => item.type === "FORHANDSVARSEL");
-        if (hasHistoricForhaandsvarsel) {
-            //Ferdigstiller tidligere forhåndsvarsel i tilfelle vurdering har endret seg før sykmeldt har lest forhåndsvarselet
-            ferdigstillVarsel();
-        }
-
-        return (
-            <AktivitetskravBox>
-                <Heading size="medium" level="2" spacing>
-                    Tidligere hendelser vedrørende din aktivitetsplikt
-                </Heading>
-
-                {historicVurderinger.map((item, index) => {
-                    return (
-                        <LinkPanel
-                            href={`/${item.vurdering.internUuid}`}
-                            border
-                            as={NextLink}
-                            key={index}
-                        >
-                            <LinkPanel.Title>
-                                {getShortDateFormat(item.vurdering.createdAt)}:{" "}
-                                {getHeaderText(item)}
-                            </LinkPanel.Title>
-                        </LinkPanel>
-                    );
-                })}
-            </AktivitetskravBox>
-        );
+export const HistoricEventsSummary = ({ historicVurderinger }: Props) => {
+  if (historicVurderinger && historicVurderinger.length > 0) {
+    const hasHistoricForhaandsvarsel = !!historicVurderinger.find(
+      (item) => item.type === "FORHANDSVARSEL",
+    );
+    if (hasHistoricForhaandsvarsel) {
+      //Ferdigstiller tidligere forhåndsvarsel i tilfelle vurdering har endret seg før sykmeldt har lest forhåndsvarselet
+      ferdigstillVarsel();
     }
-    return null;
+
+    return (
+      <AktivitetskravBox>
+        <Heading size="medium" level="2" spacing>
+          Tidligere hendelser vedrørende din aktivitetsplikt
+        </Heading>
+
+        {historicVurderinger.map((item, index) => {
+          return (
+            <LinkPanel
+              href={`/${item.vurdering.internUuid}`}
+              border
+              as={NextLink}
+              key={index}
+            >
+              <LinkPanel.Title>
+                {getShortDateFormat(item.vurdering.createdAt)}:{" "}
+                {getHeaderText(item)}
+              </LinkPanel.Title>
+            </LinkPanel>
+          );
+        })}
+      </AktivitetskravBox>
+    );
+  }
+  return null;
 };

--- a/src/components/history/HistoricEventsSummary.tsx
+++ b/src/components/history/HistoricEventsSummary.tsx
@@ -1,52 +1,60 @@
-import { AktivitetskravBox } from "@/components/box/AktivitetskravBox";
-import { Heading, LinkPanel } from "@navikt/ds-react";
+import {AktivitetskravBox} from "@/components/box/AktivitetskravBox";
+import {Heading, LinkPanel} from "@navikt/ds-react";
 import NextLink from "next/link";
 import React from "react";
-import { getShortDateFormat } from "@/utils/dateUtils";
-import { AktivitetskravViewItem } from "@/components/view/viewUtils";
+import {getShortDateFormat} from "@/utils/dateUtils";
+import {AktivitetskravViewItem} from "@/components/view/viewUtils";
+import {ferdigstillVarsel} from "@/data/ferdigstillVarsel";
 
 const getHeaderText = (viewItem: AktivitetskravViewItem) => {
-  switch (viewItem.type) {
-    case "UNDER_BEHANDLING":
-      return "NAV vurderer aktivitetsplikten din";
-    case "IKKE_OPPFYLT":
-      return "Svarfristen har gått ut";
-    case "FORHANDSVARSEL":
-      return "Forhåndsvarsel om stans av sykepenger";
-    case "MOTTATT_VURDERING":
-      return "Du har mottatt en vurdering av din aktivitetsplikt";
-  }
+    switch (viewItem.type) {
+        case "UNDER_BEHANDLING":
+            return "NAV vurderer aktivitetsplikten din";
+        case "IKKE_OPPFYLT":
+            return "Svarfristen har gått ut";
+        case "FORHANDSVARSEL":
+            return "Forhåndsvarsel om stans av sykepenger";
+        case "MOTTATT_VURDERING":
+            return "Du har mottatt en vurdering av din aktivitetsplikt";
+    }
 };
 
 interface Props {
-  historicVurderinger: AktivitetskravViewItem[] | null;
+    historicVurderinger: AktivitetskravViewItem[] | null;
 }
 
-export const HistoricEventsSummary = ({ historicVurderinger }: Props) => {
-  if (historicVurderinger && historicVurderinger.length > 0) {
-    return (
-      <AktivitetskravBox>
-        <Heading size="medium" level="2" spacing>
-          Tidligere hendelser vedrørende din aktivitetsplikt
-        </Heading>
+export const HistoricEventsSummary = ({historicVurderinger}: Props) => {
+    if (historicVurderinger && historicVurderinger.length > 0) {
 
-        {historicVurderinger.map((item, index) => {
-          return (
-            <LinkPanel
-              href={`/${item.vurdering.internUuid}`}
-              border
-              as={NextLink}
-              key={index}
-            >
-              <LinkPanel.Title>
-                {getShortDateFormat(item.vurdering.createdAt)}:{" "}
-                {getHeaderText(item)}
-              </LinkPanel.Title>
-            </LinkPanel>
-          );
-        })}
-      </AktivitetskravBox>
-    );
-  }
-  return null;
+        const hasHistoricForhaandsvarsel = !!historicVurderinger.find((item) => item.type === "FORHANDSVARSEL");
+        if (hasHistoricForhaandsvarsel) {
+            //Ferdigstiller tidligere forhåndsvarsel i tilfelle vurdering har endret seg før sykmeldt har lest forhåndsvarselet
+            ferdigstillVarsel();
+        }
+
+        return (
+            <AktivitetskravBox>
+                <Heading size="medium" level="2" spacing>
+                    Tidligere hendelser vedrørende din aktivitetsplikt
+                </Heading>
+
+                {historicVurderinger.map((item, index) => {
+                    return (
+                        <LinkPanel
+                            href={`/${item.vurdering.internUuid}`}
+                            border
+                            as={NextLink}
+                            key={index}
+                        >
+                            <LinkPanel.Title>
+                                {getShortDateFormat(item.vurdering.createdAt)}:{" "}
+                                {getHeaderText(item)}
+                            </LinkPanel.Title>
+                        </LinkPanel>
+                    );
+                })}
+            </AktivitetskravBox>
+        );
+    }
+    return null;
 };

--- a/src/components/history/HistoricEventsSummary.tsx
+++ b/src/components/history/HistoricEventsSummary.tsx
@@ -25,10 +25,7 @@ interface Props {
 
 export const HistoricEventsSummary = ({ historicVurderinger }: Props) => {
   if (historicVurderinger && historicVurderinger.length > 0) {
-    const hasHistoricForhaandsvarsel = !!historicVurderinger.find(
-      (item) => item.type === "FORHANDSVARSEL",
-    );
-    if (hasHistoricForhaandsvarsel) {
+    if (historicVurderinger?.some((item) => item.type === "FORHANDSVARSEL")) {
       //Ferdigstiller tidligere forhåndsvarsel i tilfelle vurdering har endret seg før sykmeldt har lest forhåndsvarselet
       ferdigstillVarsel();
     }

--- a/src/components/view/ForhandsvarselComponent.tsx
+++ b/src/components/view/ForhandsvarselComponent.tsx
@@ -11,7 +11,7 @@ interface Props {
 
 export const ForhandsvarselComponent = ({ vurdering }: Props) => {
   useEffect(() => {
-      ferdigstillVarsel();
+    ferdigstillVarsel();
   }, []);
 
   if (vurdering.status !== "FORHANDSVARSEL") return null;

--- a/src/components/view/ForhandsvarselComponent.tsx
+++ b/src/components/view/ForhandsvarselComponent.tsx
@@ -1,24 +1,17 @@
-import { BodyLong, Heading, Link, Tag } from "@navikt/ds-react";
-import React, { useEffect } from "react";
-import { post } from "@/data/api";
-import { AktivitetskravVurdering } from "@/schema/aktivitetskravVurderingSchema";
-import { getShortDateFormat } from "@/utils/dateUtils";
-import { ComponentHeader } from "@/components/header/ComponentHeader";
+import {BodyLong, Heading, Link, Tag} from "@navikt/ds-react";
+import React, {useEffect} from "react";
+import {AktivitetskravVurdering} from "@/schema/aktivitetskravVurderingSchema";
+import {getShortDateFormat} from "@/utils/dateUtils";
+import {ComponentHeader} from "@/components/header/ComponentHeader";
+import {ferdigstillVarsel} from "@/data/ferdigstillVarsel";
 
 interface Props {
   vurdering: AktivitetskravVurdering;
 }
 
-const ferdigstiltSessionStorageKey = "ferdigstilt-forhandsvarsel";
 export const ForhandsvarselComponent = ({ vurdering }: Props) => {
   useEffect(() => {
-    const hasAlreadyFerdigstilt = sessionStorage.getItem(
-      ferdigstiltSessionStorageKey,
-    );
-    if (!hasAlreadyFerdigstilt) {
-      post(`${process.env.NEXT_PUBLIC_ESYFO_PROXY_API_URL!}/les`);
-      sessionStorage.setItem(ferdigstiltSessionStorageKey, "true");
-    }
+      ferdigstillVarsel();
   }, []);
 
   if (vurdering.status !== "FORHANDSVARSEL") return null;

--- a/src/components/view/ForhandsvarselComponent.tsx
+++ b/src/components/view/ForhandsvarselComponent.tsx
@@ -1,9 +1,9 @@
-import {BodyLong, Heading, Link, Tag} from "@navikt/ds-react";
-import React, {useEffect} from "react";
-import {AktivitetskravVurdering} from "@/schema/aktivitetskravVurderingSchema";
-import {getShortDateFormat} from "@/utils/dateUtils";
-import {ComponentHeader} from "@/components/header/ComponentHeader";
-import {ferdigstillVarsel} from "@/data/ferdigstillVarsel";
+import { BodyLong, Heading, Link, Tag } from "@navikt/ds-react";
+import React, { useEffect } from "react";
+import { AktivitetskravVurdering } from "@/schema/aktivitetskravVurderingSchema";
+import { getShortDateFormat } from "@/utils/dateUtils";
+import { ComponentHeader } from "@/components/header/ComponentHeader";
+import { ferdigstillVarsel } from "@/data/ferdigstillVarsel";
 
 interface Props {
   vurdering: AktivitetskravVurdering;

--- a/src/data/ferdigstillVarsel.ts
+++ b/src/data/ferdigstillVarsel.ts
@@ -1,12 +1,12 @@
-import {post} from "@/data/api";
+import { post } from "@/data/api";
 
 export const ferdigstillVarsel = () => {
-    const ferdigstiltSessionStorageKey = "ferdigstilt-forhandsvarsel";
-    const hasAlreadyFerdigstilt = sessionStorage.getItem(
-        ferdigstiltSessionStorageKey,
-    );
-    if (!hasAlreadyFerdigstilt) {
-        post(`${process.env.NEXT_PUBLIC_ESYFO_PROXY_API_URL!}/les`);
-        sessionStorage.setItem(ferdigstiltSessionStorageKey, "true");
-    }
-}
+  const ferdigstiltSessionStorageKey = "ferdigstilt-forhandsvarsel";
+  const hasAlreadyFerdigstilt = sessionStorage.getItem(
+    ferdigstiltSessionStorageKey,
+  );
+  if (!hasAlreadyFerdigstilt) {
+    post(`${process.env.NEXT_PUBLIC_ESYFO_PROXY_API_URL!}/les`);
+    sessionStorage.setItem(ferdigstiltSessionStorageKey, "true");
+  }
+};

--- a/src/data/ferdigstillVarsel.ts
+++ b/src/data/ferdigstillVarsel.ts
@@ -1,0 +1,12 @@
+import {post} from "@/data/api";
+
+export const ferdigstillVarsel = () => {
+    const ferdigstiltSessionStorageKey = "ferdigstilt-forhandsvarsel";
+    const hasAlreadyFerdigstilt = sessionStorage.getItem(
+        ferdigstiltSessionStorageKey,
+    );
+    if (!hasAlreadyFerdigstilt) {
+        post(`${process.env.NEXT_PUBLIC_ESYFO_PROXY_API_URL!}/les`);
+        sessionStorage.setItem(ferdigstiltSessionStorageKey, "true");
+    }
+}


### PR DESCRIPTION
Dersom vurdering har endret seg fra forhåndsvarsel til noe annet før bruker har sett det, så vil ikke ferdigstilling av varsel/oppgave gjøres uten at bruker klikker seg inn på det (tidligere) forhåndsvarselet i historikk-visningen.

Endrer slik at vi nå kjører ferdigstill uansett dersom du har et forhåndsvarsel