### PR TITLE
IS-1801: Tilpass ny vurderingstype INNSTILLING_OM_STANS

### DIFF
--- a/src/components/history/HistoricEventsSummary.tsx
+++ b/src/components/history/HistoricEventsSummary.tsx
@@ -11,6 +11,7 @@ const getHeaderText = (viewItem: AktivitetskravViewItem) => {
   switch (viewItem.type) {
     case "UNDER_BEHANDLING":
       return "NAV vurderer aktivitetsplikten din";
+    case "INNSTILLING_OM_STANS":
     case "IKKE_OPPFYLT":
       return "Svarfristen har gått ut";
     case "FORHANDSVARSEL":

--- a/src/components/testscenarioselector/TestScenarioSelector.tsx
+++ b/src/components/testscenarioselector/TestScenarioSelector.tsx
@@ -7,7 +7,7 @@ import {
   ForhandsvarselTestScenario,
   getTestScenario,
   IkkeAktuellTestScenario,
-  IkkeOppfyltTestScenario,
+  InnstillingOmStansTestScenario,
   InfoSideTestScenario,
   OppfyltTestScenario,
   setTestScenario,
@@ -50,7 +50,7 @@ export const TestScenarioSelector = () => {
               <Radio value={InfoSideTestScenario}>Ny kandidat</Radio>
               <Radio value={ForhandsvarselTestScenario}>Forhåndsvarsel</Radio>
               <Radio value={IkkeAktuellTestScenario}>Ikke aktuell</Radio>
-              <Radio value={IkkeOppfyltTestScenario}>Ikke oppfylt</Radio>
+              <Radio value={InnstillingOmStansTestScenario}>Innstilling om stans</Radio>
               <Radio value={UnntakTestScenario}>Unntak</Radio>
               <Radio value={OppfyltTestScenario}>Oppfylt</Radio>
             </RadioGroup>

--- a/src/components/view/Vurdering.tsx
+++ b/src/components/view/Vurdering.tsx
@@ -20,6 +20,7 @@ export const Vurdering = ({ viewItem }: Props): ReactElement | null => {
       return <MottattVurderingComponent vurdering={viewItem.vurdering} />;
     case "UNDER_BEHANDLING":
       return <UnderBehandlingComponent vurdering={viewItem.vurdering} />;
+    case "INNSTILLING_OM_STANS":
     case "IKKE_OPPFYLT":
       return <IkkeOppfyltComponent vurdering={viewItem.vurdering} />;
     default:

--- a/src/components/view/viewUtils.ts
+++ b/src/components/view/viewUtils.ts
@@ -5,6 +5,7 @@ export interface AktivitetskravViewItem {
     | "UNDER_BEHANDLING"
     | "FORHANDSVARSEL"
     | "MOTTATT_VURDERING"
+    | "INNSTILLING_OM_STANS"
     | "IKKE_OPPFYLT";
   vurdering: AktivitetskravVurdering;
 }
@@ -40,9 +41,10 @@ export const mapVurderingToViewItem = (
         type: "MOTTATT_VURDERING",
         vurdering: vurdering,
       };
+    case "INNSTILLING_OM_STANS":
     case "IKKE_OPPFYLT": {
       return {
-        type: "IKKE_OPPFYLT",
+        type: "INNSTILLING_OM_STANS",
         vurdering: vurdering,
       };
     }

--- a/src/schema/aktivitetskravVurderingSchema.ts
+++ b/src/schema/aktivitetskravVurderingSchema.ts
@@ -8,6 +8,7 @@ const VurderingStatusSchema = z.union([
   literal("NY_VURDERING"),
   literal("AVVENT"),
   literal("FORHANDSVARSEL"),
+  literal("INNSTILLING_OM_STANS"),
   literal("IKKE_OPPFYLT"),
   literal("IKKE_AKTUELL"),
 ]);
@@ -70,6 +71,11 @@ export const IkkeOppfyltSchema = BaseVurdering.extend({
   sistVurdert: string().datetime(),
 });
 
+export const InnstillingOmStansSchema = BaseVurdering.extend({
+  status: z.literal("INNSTILLING_OM_STANS"),
+  sistVurdert: string().datetime(),
+});
+
 export const IkkeAktuellSchema = BaseVurdering.extend({
   status: z.literal("IKKE_AKTUELL"),
   sistVurdert: string().datetime(),
@@ -83,6 +89,7 @@ export const aktivitetskravVurderingSchema = union([
   AvventSchema,
   ForhandsvarselSchema,
   IkkeOppfyltSchema,
+  InnstillingOmStansSchema,
   IkkeAktuellSchema,
 ]);
 
@@ -97,6 +104,7 @@ export type NyVurdering = z.infer<typeof NyVurderingSchema>;
 export type Avvent = z.infer<typeof AvventSchema>;
 export type Forhandsvarsel = z.infer<typeof ForhandsvarselSchema>;
 export type IkkeOppfylt = z.infer<typeof IkkeOppfyltSchema>;
+export type InnstillingOmStans = z.infer<typeof InnstillingOmStansSchema>;
 export type IkkeAktuell = z.infer<typeof IkkeAktuellSchema>;
 export type UnntakArsaker = z.infer<typeof unntakArsaker>;
 export type OppfyltArsaker = z.infer<typeof oppfyltArsaker>;

--- a/src/utils/testScenarioUtils.ts
+++ b/src/utils/testScenarioUtils.ts
@@ -4,7 +4,7 @@ import { AktivitetskravVurdering } from "@/schema/aktivitetskravVurderingSchema"
 export type TestScenario =
   | typeof InfoSideTestScenario
   | typeof IkkeAktuellTestScenario
-  | typeof IkkeOppfyltTestScenario
+  | typeof InnstillingOmStansTestScenario
   | typeof UnntakTestScenario
   | typeof OppfyltTestScenario
   | typeof ForhandsvarselTestScenario;
@@ -12,7 +12,7 @@ export type TestScenario =
 export const InfoSideTestScenario = "INFOSIDE";
 export const ForhandsvarselTestScenario = "FORHANDSVARSEL";
 export const IkkeAktuellTestScenario = "IKKEAKTUELL";
-export const IkkeOppfyltTestScenario = "IKKEOPPFYLT";
+export const InnstillingOmStansTestScenario = "INNSTILLING_OM_STANS";
 export const UnntakTestScenario = "UNNTAK";
 export const OppfyltTestScenario = "OPPFYLT";
 


### PR DESCRIPTION
Legger til støtte for `INNSTILLING_OM_STANS` vurderingstype for aktivitetskravet

Etter litt tid kan vi vel fjerne `IKKE_OPPFYLT` her(?). Vi vil slutte å sende denne vurderingen fra `syfomodiaperson`.