### PR TITLE
IS-1801: Tilpass ny vurderingstype INNSTILLING_OM_STANS

### DIFF
--- a/src/components/history/HistoricEventsSummary.tsx
+++ b/src/components/history/HistoricEventsSummary.tsx
@@ -11,6 +11,7 @@ const getHeaderText = (viewItem: AktivitetskravViewItem) => {
   switch (viewItem.type) {
     case "UNDER_BEHANDLING":
       return "NAV vurderer aktivitetsplikten din";
+    case "INNSTILLING_OM_STANS":
     case "IKKE_OPPFYLT":
       return "Svarfristen har gått ut";
     case "FORHANDSVARSEL":

--- a/src/components/testscenarioselector/TestScenarioSelector.tsx
+++ b/src/components/testscenarioselector/TestScenarioSelector.tsx
@@ -7,12 +7,12 @@ import {
   ForhandsvarselTestScenario,
   getTestScenario,
   IkkeAktuellTestScenario,
-  IkkeOppfyltTestScenario,
   InfoSideTestScenario,
+  InnstillingOmStansTestScenario,
   OppfyltTestScenario,
   setTestScenario,
   TestScenario,
-  UnntakTestScenario,
+  UnntakTestScenario
 } from "@/utils/testScenarioUtils";
 
 export const TestScenarioSelector = () => {
@@ -50,7 +50,7 @@ export const TestScenarioSelector = () => {
               <Radio value={InfoSideTestScenario}>Ny kandidat</Radio>
               <Radio value={ForhandsvarselTestScenario}>Forhåndsvarsel</Radio>
               <Radio value={IkkeAktuellTestScenario}>Ikke aktuell</Radio>
-              <Radio value={IkkeOppfyltTestScenario}>Ikke oppfylt</Radio>
+              <Radio value={InnstillingOmStansTestScenario}>Innstilling om stans</Radio>
               <Radio value={UnntakTestScenario}>Unntak</Radio>
               <Radio value={OppfyltTestScenario}>Oppfylt</Radio>
             </RadioGroup>

--- a/src/components/view/Vurdering.tsx
+++ b/src/components/view/Vurdering.tsx
@@ -20,7 +20,7 @@ export const Vurdering = ({ viewItem }: Props): ReactElement | null => {
       return <MottattVurderingComponent vurdering={viewItem.vurdering} />;
     case "UNDER_BEHANDLING":
       return <UnderBehandlingComponent vurdering={viewItem.vurdering} />;
-    case "IKKE_OPPFYLT":
+    case "INNSTILLING_OM_STANS":
       return <IkkeOppfyltComponent vurdering={viewItem.vurdering} />;
     default:
       return null;

--- a/src/components/view/viewUtils.ts
+++ b/src/components/view/viewUtils.ts
@@ -5,7 +5,8 @@ export interface AktivitetskravViewItem {
     | "UNDER_BEHANDLING"
     | "FORHANDSVARSEL"
     | "MOTTATT_VURDERING"
-    | "IKKE_OPPFYLT";
+    | "IKKE_OPPFYLT"
+    | "INNSTILLING_OM_STANS";
   vurdering: AktivitetskravVurdering;
 }
 
@@ -40,9 +41,10 @@ export const mapVurderingToViewItem = (
         type: "MOTTATT_VURDERING",
         vurdering: vurdering,
       };
+    case "INNSTILLING_OM_STANS":
     case "IKKE_OPPFYLT": {
       return {
-        type: "IKKE_OPPFYLT",
+        type: "INNSTILLING_OM_STANS",
         vurdering: vurdering,
       };
     }

--- a/src/mocks/fixtures.ts
+++ b/src/mocks/fixtures.ts
@@ -58,6 +58,17 @@ const ikkeOppfyltVurdering = (
   };
 };
 
+const innstillingOmStansVurdering = (
+  dagerSidenHendelse: number,
+): AktivitetskravVurdering => {
+  return {
+    status: "INNSTILLING_OM_STANS",
+    internUuid: "123123123",
+    createdAt: pastDateAsString(dagerSidenHendelse),
+    sistVurdert: pastDateAsString(dagerSidenHendelse),
+  };
+}
+
 const avventVurdering = (
   dagerSidenHendelse: number,
 ): AktivitetskravVurdering => {
@@ -126,6 +137,13 @@ const ikkeOppfyltFixture: AktivitetskravVurdering[] = [
   nyKandidatVurdering(14),
 ];
 
+const innstillingOmStansFixture: AktivitetskravVurdering[] = [
+  innstillingOmStansVurdering(1),
+  forhaandsvarselVurdering(4),
+  avventVurdering(7),
+  nyKandidatVurdering(14),
+];
+
 const ikkeAktuellFixture: AktivitetskravVurdering[] = [
   ikkeAktuellVurdering(13),
   forhaandsvarselVurdering(20),
@@ -145,6 +163,7 @@ const fixtures = {
   nyKandidatFixture,
   unntakFixture,
   ikkeAktuellFixture,
+  innstillingOmStansFixture,
   ikkeOppfyltFixture,
   oppfyltFixture,
 };

--- a/src/schema/aktivitetskravVurderingSchema.ts
+++ b/src/schema/aktivitetskravVurderingSchema.ts
@@ -9,6 +9,7 @@ const VurderingStatusSchema = z.union([
   literal("AVVENT"),
   literal("FORHANDSVARSEL"),
   literal("IKKE_OPPFYLT"),
+  literal("INNSTILLING_OM_STANS"),
   literal("IKKE_AKTUELL"),
 ]);
 
@@ -70,6 +71,11 @@ export const IkkeOppfyltSchema = BaseVurdering.extend({
   sistVurdert: string().datetime(),
 });
 
+export const InnstillingOmStansSchema = BaseVurdering.extend({
+  status: z.literal("INNSTILLING_OM_STANS"),
+  sistVurdert: string().datetime(),
+});
+
 export const IkkeAktuellSchema = BaseVurdering.extend({
   status: z.literal("IKKE_AKTUELL"),
   sistVurdert: string().datetime(),
@@ -83,6 +89,7 @@ export const aktivitetskravVurderingSchema = union([
   AvventSchema,
   ForhandsvarselSchema,
   IkkeOppfyltSchema,
+  InnstillingOmStansSchema,
   IkkeAktuellSchema,
 ]);
 
@@ -97,6 +104,7 @@ export type NyVurdering = z.infer<typeof NyVurderingSchema>;
 export type Avvent = z.infer<typeof AvventSchema>;
 export type Forhandsvarsel = z.infer<typeof ForhandsvarselSchema>;
 export type IkkeOppfylt = z.infer<typeof IkkeOppfyltSchema>;
+export type InnstillingOmStans = z.infer<typeof IkkeOppfyltSchema>;
 export type IkkeAktuell = z.infer<typeof IkkeAktuellSchema>;
 export type UnntakArsaker = z.infer<typeof unntakArsaker>;
 export type OppfyltArsaker = z.infer<typeof oppfyltArsaker>;

--- a/src/utils/testScenarioUtils.ts
+++ b/src/utils/testScenarioUtils.ts
@@ -4,7 +4,7 @@ import { AktivitetskravVurdering } from "@/schema/aktivitetskravVurderingSchema"
 export type TestScenario =
   | typeof InfoSideTestScenario
   | typeof IkkeAktuellTestScenario
-  | typeof IkkeOppfyltTestScenario
+  | typeof InnstillingOmStansTestScenario
   | typeof UnntakTestScenario
   | typeof OppfyltTestScenario
   | typeof ForhandsvarselTestScenario;
@@ -12,7 +12,7 @@ export type TestScenario =
 export const InfoSideTestScenario = "INFOSIDE";
 export const ForhandsvarselTestScenario = "FORHANDSVARSEL";
 export const IkkeAktuellTestScenario = "IKKEAKTUELL";
-export const IkkeOppfyltTestScenario = "IKKEOPPFYLT";
+export const InnstillingOmStansTestScenario = "INNSTILLING_OM_STANS";
 export const UnntakTestScenario = "UNNTAK";
 export const OppfyltTestScenario = "OPPFYLT";
 
@@ -46,7 +46,7 @@ export const getAktivitetskravVurderingForScenario = (
     case "IKKEAKTUELL": {
       return fixtures.ikkeAktuellFixture;
     }
-    case "IKKEOPPFYLT": {
+    case "INNSTILLING_OM_STANS": {
       return fixtures.ikkeOppfyltFixture;
     }
     case "UNNTAK": {


### PR DESCRIPTION
Legger til støtte for INNSTILLING_OM_STANS vurderingstype for aktivitetskravet

Etter litt tid kan vi vel fjerne IKKE_OPPFYLT her(?). Vi vil slutte å sende denne vurderingen fra syfomodiaperson.

Se [tilhørende PR](https://github.com/navikt/aktivitetskrav-backend/pull/103) i `aktivitetskrav-backend`

Erstatter visning for `IKKE_OPPFYLT` vurdering.
Screenshot fra test i dev hvor siste vurdering har status `INNSTILLING_OM_STANS`
![Screenshot 2025-02-19 at 15 49 01](https://github.com/user-attachments/assets/50c5f904-1913-49b6-a02e-464dda7fbc01)

Er det riktig at vurderingen ikke skal ha journalpost?
![Screenshot 2025-02-19 at 15 48 50](https://github.com/user-attachments/assets/9ab06195-f0b8-4fc6-960f-1c613ea70dcb)
