### PR TITLE
docs(readme): oppdater lenke til frontend-wiki og legg til kontaktinfo

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,14 @@ Endpoints som brukes:
 
 ## Utvikling (kjøre lokalt)
 
-For å komme i gang med bygging og kjøring av appen, les vår [wiki for Next.js-applikasjoner](https://github.com/navikt/esyfo-dev-tools/wiki/nextjs-build-run).
+For å komme i gang med å bygge og kjøre appen, se vår [Wiki for frontendapper](https://navikt.github.io/team-esyfo/utvikling/frontend/).
 
 Når appen er startet, åpne http://localhost:3000/syk/aktivitetskrav
+
+## For Nav-ansatte
+
+Interne henvendelser kan sendes via Slack i kanalen [#esyfo](https://nav-it.slack.com/archives/C012X796B4L).
+
+---
 
 [^basepath]: `basePath`-verdien settes i Next.js-konfigurasjonen i `next.config.ts` og angir URL-prefikset som hele appen lever under.

--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@
 
 ## Miljøer
 
-[🚀 Produksjon](https://www.nav.no/syk/aktivitetskrav)
+🚀 [Produksjon](https://www.nav.no/syk/aktivitetskrav)
 
-[🛠️ Utvikling](https://www.ekstern.dev.nav.no/syk/aktivitetskrav)
+🛠️ [Utvikling](https://www.ekstern.dev.nav.no/syk/aktivitetskrav)
 
-[🎬 Demo](https://demo.ekstern.dev.nav.no/syk/aktivitetskrav)
+🎬 [Demo](https://demo.ekstern.dev.nav.no/syk/aktivitetskrav)
 
 ## Formål med appen
 


### PR DESCRIPTION
## Beskrivelse

Oppdaterer README med riktig lenke til frontend-wikien og legger til kontaktinfo for Nav-ansatte.

## Endringer

- `README.md`: Oppdatert wiki-lenke fra gammel GitHub-wiki til ny team-esyfo-docs
- `README.md`: Lagt til «For Nav-ansatte»-seksjon med Slack-kanal

## Issue

Ingen tilknyttet issue — enkel dokumentasjonsoppdatering.

## Sjekkliste

- [x] Koden kompilerer og linter uten feil
- [x] Endringene er testet (manuelt eller automatisk)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)