### PR TITLE
build(deps): bump pnpm to 11.3.0

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,6 @@
 [tools]
 node = "24"
-pnpm = "10"
+pnpm = "11.3.0"
 
 [tasks.install]
 description = "Install dependencies (cached)"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
-  "packageManager": "pnpm@10.29.2",
+  "packageManager": "pnpm@11.3.0",
   "scripts": {
     "dev": "next dev",
     "build": "next build",
@@ -54,10 +54,5 @@
     "typescript": "^6",
     "vite": "^8.0.13",
     "vitest": "^4.1.4"
-  },
-  "pnpm": {
-    "overrides": {
-      "jsdom": "26.1.0"
-    }
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,12 @@
+allowBuilds:
+  esbuild: true
+  protobufjs: true
+  sharp: true
+minimumReleaseAge: 4320
+minimumReleaseAgeExclude:
+  - '@babel/code-frame@7.29.7'
+  - '@babel/helper-validator-identifier@7.29.7'
+  - '@babel/runtime@7.29.7'
+blockExoticSubdeps: true
+overrides:
+  jsdom: 26.1.0


### PR DESCRIPTION
## Beskrivelse

Bumper pnpm til `11.3.0` og legger til pnpm 11-kompatibel supply-chain-konfigurasjon for install/build-policy.

## Endringer

- `package.json`: oppdaterer `packageManager` til `pnpm@11.3.0` og flytter pnpm-overrides ut av `package.json`
- `mise.toml`: oppdaterer pnpm-verktøyversjon til `11.3.0`
- `pnpm-workspace.yaml`: legger til `allowBuilds`, `minimumReleaseAge`, `blockExoticSubdeps` og `overrides.jsdom`

## Issue

Closes #1404

## Verifisering

- `npx --yes pnpm@11.3.0 install --frozen-lockfile`
- `npx --yes pnpm@11.3.0 run build`
- `npx --yes pnpm@11.3.0 run test`
- `npx --yes pnpm@11.3.0 ls jsdom`
- `npx --yes pnpm@11.3.0 config get allowBuilds --location project --json`

Merk: `pnpm run check` feiler på kjente, urelaterte Biome-funn som fantes fra før.

## Sjekkliste

- [x] Koden kompilerer
- [x] Endringene er testet (manuelt eller automatisk)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)
- [ ] Lint/check er grønn (blokkeres av eksisterende urelaterte Biome-funn)
